### PR TITLE
Fix : Order

### DIFF
--- a/src/main/java/com/DevTino/festino_main/order/bean/SaveOrderBean.java
+++ b/src/main/java/com/DevTino/festino_main/order/bean/SaveOrderBean.java
@@ -35,6 +35,9 @@ public class SaveOrderBean {
         NightBoothDAO nightBoothDAO = getNightBoothDAOBean.exec(requestOrderSaveDTO.getBoothId());
         if (nightBoothDAO == null) return null;
 
+        // 부스가 닫혀 있거나 주문 불가할 경우 주문 등록 실패
+        if (!nightBoothDAO.getIsOpen() || !nightBoothDAO.getIsOrder()) return null;
+
         // 날짜 조회
         Integer date = checkOrderDAODateFieldBean.exec(nightBoothDAO);
 


### PR DESCRIPTION

## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Main-BE/issues/59#issue-2461434228)
 
## Changes
order 생성 시 부스가 닫혀 있거나 주문 불가한 상태일 경우 order가 생성되지 않도록 수정

## Review Points
- [x] 주문 생성 API 수정 : isOpen과 isOrder 체크하도록

## Test Checklist
주문 생성 API가 적절히 수정되었으며 잘 동작하는가
- [x] 주문 생성 API : `/main/order` - `POST`