### PR TITLE
fix : add `isService` field to `OrderDAO`

### DIFF
--- a/src/main/java/com/DevTino/festino_main/order/bean/small/CreateOrderDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/order/bean/small/CreateOrderDAOBean.java
@@ -27,6 +27,7 @@ public class CreateOrderDAOBean {
                 .createAt(DateTimeUtils.nowZone())
                 .isCoupon(requestOrderSaveDTO.getIsCoupon())
                 .isDeposit(false)
+                .isService(false)
                 .build();
     }
 }

--- a/src/main/java/com/DevTino/festino_main/order/domain/BiochemistryOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/BiochemistryOrderDAO.java
@@ -32,6 +32,7 @@ public class BiochemistryOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class BiochemistryOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/BusinessOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/BusinessOrderDAO.java
@@ -32,6 +32,7 @@ public class BusinessOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class BusinessOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/ComputerOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/ComputerOrderDAO.java
@@ -32,6 +32,7 @@ public class ComputerOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class ComputerOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/DTO/OrderDTO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/DTO/OrderDTO.java
@@ -25,6 +25,7 @@ public class OrderDTO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -43,6 +44,7 @@ public class OrderDTO {
                 .createAt(computerOrderDAO.getCreateAt())
                 .isCoupon(computerOrderDAO.getIsCoupon())
                 .isDeposit(computerOrderDAO.getIsDeposit())
+                .isService(computerOrderDAO.getIsService())
                 .menuInfo(computerOrderDAO.getMenuInfo())
                 .build();
     }
@@ -61,6 +63,7 @@ public class OrderDTO {
                 .createAt(gameOrderDAO.getCreateAt())
                 .isCoupon(gameOrderDAO.getIsCoupon())
                 .isDeposit(gameOrderDAO.getIsDeposit())
+                .isService(gameOrderDAO.getIsService())
                 .menuInfo(gameOrderDAO.getMenuInfo())
                 .build();
     }
@@ -79,6 +82,7 @@ public class OrderDTO {
                 .createAt(nanoOrderDAO.getCreateAt())
                 .isCoupon(nanoOrderDAO.getIsCoupon())
                 .isDeposit(nanoOrderDAO.getIsDeposit())
+                .isService(nanoOrderDAO.getIsService())
                 .menuInfo(nanoOrderDAO.getMenuInfo())
                 .build();
     }
@@ -97,6 +101,7 @@ public class OrderDTO {
                 .createAt(newMaterialOrderDAO.getCreateAt())
                 .isCoupon(newMaterialOrderDAO.getIsCoupon())
                 .isDeposit(newMaterialOrderDAO.getIsDeposit())
+                .isService(newMaterialOrderDAO.getIsService())
                 .menuInfo(newMaterialOrderDAO.getMenuInfo())
                 .build();
     }
@@ -115,6 +120,7 @@ public class OrderDTO {
                 .createAt(designOrderDAO.getCreateAt())
                 .isCoupon(designOrderDAO.getIsCoupon())
                 .isDeposit(designOrderDAO.getIsDeposit())
+                .isService(designOrderDAO.getIsService())
                 .menuInfo(designOrderDAO.getMenuInfo())
                 .build();
     }
@@ -133,6 +139,7 @@ public class OrderDTO {
                 .createAt(machineOrderDAO.getCreateAt())
                 .isCoupon(machineOrderDAO.getIsCoupon())
                 .isDeposit(machineOrderDAO.getIsDeposit())
+                .isService(machineOrderDAO.getIsService())
                 .menuInfo(machineOrderDAO.getMenuInfo())
                 .build();
     }
@@ -151,6 +158,7 @@ public class OrderDTO {
                 .createAt(electronicsOrderDAO.getCreateAt())
                 .isCoupon(electronicsOrderDAO.getIsCoupon())
                 .isDeposit(electronicsOrderDAO.getIsDeposit())
+                .isService(electronicsOrderDAO.getIsService())
                 .menuInfo(electronicsOrderDAO.getMenuInfo())
                 .build();
     }
@@ -169,6 +177,7 @@ public class OrderDTO {
                 .createAt(energyOrderDAO.getCreateAt())
                 .isCoupon(energyOrderDAO.getIsCoupon())
                 .isDeposit(energyOrderDAO.getIsDeposit())
+                .isService(energyOrderDAO.getIsService())
                 .menuInfo(energyOrderDAO.getMenuInfo())
                 .build();
     }
@@ -187,6 +196,7 @@ public class OrderDTO {
                 .createAt(mechatronicsOrderDAO.getCreateAt())
                 .isCoupon(mechatronicsOrderDAO.getIsCoupon())
                 .isDeposit(mechatronicsOrderDAO.getIsDeposit())
+                .isService(mechatronicsOrderDAO.getIsService())
                 .menuInfo(mechatronicsOrderDAO.getMenuInfo())
                 .build();
     }
@@ -205,6 +215,7 @@ public class OrderDTO {
                 .createAt(biochemistryOrderDAO.getCreateAt())
                 .isCoupon(biochemistryOrderDAO.getIsCoupon())
                 .isDeposit(biochemistryOrderDAO.getIsDeposit())
+                .isService(biochemistryOrderDAO.getIsService())
                 .menuInfo(biochemistryOrderDAO.getMenuInfo())
                 .build();
     }
@@ -223,6 +234,7 @@ public class OrderDTO {
                 .createAt(machinedesignOrderDAO.getCreateAt())
                 .isCoupon(machinedesignOrderDAO.getIsCoupon())
                 .isDeposit(machinedesignOrderDAO.getIsDeposit())
+                .isService(machinedesignOrderDAO.getIsService())
                 .menuInfo(machinedesignOrderDAO.getMenuInfo())
                 .build();
     }
@@ -241,6 +253,7 @@ public class OrderDTO {
                 .createAt(businessOrderDAO.getCreateAt())
                 .isCoupon(businessOrderDAO.getIsCoupon())
                 .isDeposit(businessOrderDAO.getIsDeposit())
+                .isService(businessOrderDAO.getIsService())
                 .menuInfo(businessOrderDAO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/DesignOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/DesignOrderDAO.java
@@ -32,6 +32,7 @@ public class DesignOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class DesignOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/ElectronicsOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/ElectronicsOrderDAO.java
@@ -32,6 +32,7 @@ public class ElectronicsOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class ElectronicsOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/EnergyOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/EnergyOrderDAO.java
@@ -32,6 +32,7 @@ public class EnergyOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class EnergyOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/GameOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/GameOrderDAO.java
@@ -32,6 +32,7 @@ public class GameOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class GameOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/MachineOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/MachineOrderDAO.java
@@ -32,6 +32,7 @@ public class MachineOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class MachineOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/MachinedesignOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/MachinedesignOrderDAO.java
@@ -32,6 +32,7 @@ public class MachinedesignOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class MachinedesignOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/MechatronicsOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/MechatronicsOrderDAO.java
@@ -32,6 +32,7 @@ public class MechatronicsOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class MechatronicsOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/NanoOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/NanoOrderDAO.java
@@ -32,6 +32,7 @@ public class NanoOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class NanoOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }

--- a/src/main/java/com/DevTino/festino_main/order/domain/NewMaterialOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_main/order/domain/NewMaterialOrderDAO.java
@@ -32,6 +32,7 @@ public class NewMaterialOrderDAO {
     LocalDateTime createAt;
     Boolean isCoupon;
     Boolean isDeposit;
+    Boolean isService;
 
     @Convert(converter = StringListConverter.class)
     List<Map<String, Object>> menuInfo;
@@ -49,6 +50,7 @@ public class NewMaterialOrderDAO {
                 .createAt(orderDTO.getCreateAt())
                 .isCoupon(orderDTO.getIsCoupon())
                 .isDeposit(orderDTO.getIsDeposit())
+                .isService(orderDTO.getIsService())
                 .menuInfo(orderDTO.getMenuInfo())
                 .build();
     }


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Main-BE/issues/65#issue-2496594645)
 
## Changes
- 학과별 Order DAO 및 DTO에 isService 필드 추가
- Order 생성 시 isService 값 설정하도록 변경

## Test Checklist
학과별 OrderDAO 및 주문 생성 API가 적절히 수정되었으며 잘 동작하는가
- [x] 주문 생성 API : `/main/order` - `POST`