### PR TITLE
Fix : TableNum

### DIFF
--- a/src/main/java/com/DevTino/festino_main/order/bean/GetCustomTableNumBean.java
+++ b/src/main/java/com/DevTino/festino_main/order/bean/GetCustomTableNumBean.java
@@ -1,6 +1,7 @@
 package com.DevTino.festino_main.order.bean;
 
 import com.DevTino.festino_main.order.bean.small.GetCustomTableNumDAOBean;
+import com.DevTino.festino_main.order.domain.TableNumDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +18,10 @@ public class GetCustomTableNumBean {
     }
 
     public String exec(Integer tableNumIndex, UUID boothId) {
-        return getCustomTableNumDAOBean.exec(tableNumIndex, boothId).getCustomTableNum();
+
+        TableNumDAO tableNumDAO = getCustomTableNumDAOBean.exec(tableNumIndex, boothId);
+        if(tableNumDAO == null) return null;
+
+        return tableNumDAO.getCustomTableNum();
     }
 }


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Main-BE/issues/72)
 
## Changes
before
tableNumIndex와 boothId를 통해 원하는 테이블DAO를 찾은다음 바로 customTableNum을 가져온다.
이때 테이블DAO가 null값일시 nullPointerExcepetion 발생

after
테이블DAO가 null 값일때 예외처리를 추가해 nullPointerException 방지