### PR TITLE
feat: implement save API for event photo

### DIFF
--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/DeletePhotoBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/DeletePhotoBean.java
@@ -1,0 +1,40 @@
+package com.DevTino.festino_main.event.photo.bean;
+
+import com.DevTino.festino_main.event.photo.bean.small.DeletePhotoDAOBean;
+import com.DevTino.festino_main.event.photo.bean.small.GetPhotoDAOBean;
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class DeletePhotoBean {
+
+    GetPhotoDAOBean getPhotoDAOBean;
+    DeletePhotoDAOBean deletePhotoDAOBean;
+
+    @Autowired
+    public DeletePhotoBean(GetPhotoDAOBean getPhotoDAOBean, DeletePhotoDAOBean deletePhotoDAOBean){
+        this.getPhotoDAOBean = getPhotoDAOBean;
+        this.deletePhotoDAOBean = deletePhotoDAOBean;
+    }
+
+    // 사진 게시물 삭제
+    public UUID exec(RequestPhotoDeleteDTO requestPhotoDeleteDTO){
+
+        // photo 존재여부 판단
+        PhotoDAO photoDAO = getPhotoDAOBean.exec(requestPhotoDeleteDTO.getPhotoId());
+        if (photoDAO == null) return null; // 존재하지 않는 photoId
+
+        // user 일치여부 판단
+        if (!requestPhotoDeleteDTO.getMainUserId().equals(photoDAO.getMainUserId())) return null; // userId 불일치
+
+        // photo 삭제
+        deletePhotoDAOBean.exec(photoDAO);
+
+        // photoId 반환
+        return requestPhotoDeleteDTO.getPhotoId();
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/GetMainUserPhotosBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/GetMainUserPhotosBean.java
@@ -1,0 +1,33 @@
+package com.DevTino.festino_main.event.photo.bean;
+
+import com.DevTino.festino_main.event.photo.bean.small.CreatePhotosDTOBean;
+import com.DevTino.festino_main.event.photo.bean.small.GetPhotosDAOBean;
+import com.DevTino.festino_main.event.photo.domain.dto.ResponsePhotoGetDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class GetMainUserPhotosBean {
+
+    GetPhotosDAOBean getPhotosDAOBean;
+    CreatePhotosDTOBean createPhotosDTOBean;
+
+    @Autowired
+    public GetMainUserPhotosBean(GetPhotosDAOBean getPhotosDAOBean, CreatePhotosDTOBean createPhotosDTOBean) {
+        this.getPhotosDAOBean = getPhotosDAOBean;
+        this.createPhotosDTOBean = createPhotosDTOBean;
+    }
+
+    public List<ResponsePhotoGetDTO> exec(UUID mainUserId, String type){
+
+        // 사진 타입 별로 정렬해서 가져오기
+        List<PhotoDAO> photoDAOList = getPhotosDAOBean.exec(type);
+
+        // DAO -> DTO 변환 및 반환
+        return createPhotosDTOBean.exec(mainUserId, photoDAOList);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/GetPhotosBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/GetPhotosBean.java
@@ -1,0 +1,32 @@
+package com.DevTino.festino_main.event.photo.bean;
+
+import com.DevTino.festino_main.event.photo.bean.small.CreatePhotosDTOBean;
+import com.DevTino.festino_main.event.photo.bean.small.GetPhotosDAOBean;
+import com.DevTino.festino_main.event.photo.domain.dto.ResponsePhotoGetDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetPhotosBean {
+
+    GetPhotosDAOBean getPhotosDAOBean;
+    CreatePhotosDTOBean createPhotosDTOBean;
+
+    @Autowired
+    public GetPhotosBean(GetPhotosDAOBean getPhotosDAOBean, CreatePhotosDTOBean createPhotosDTOBean) {
+        this.getPhotosDAOBean = getPhotosDAOBean;
+        this.createPhotosDTOBean = createPhotosDTOBean;
+    }
+
+    public List<ResponsePhotoGetDTO> exec(String type){
+
+        // 사진 타입 별로 정렬해서 가져오기
+        List<PhotoDAO> photoDAOList = getPhotosDAOBean.exec(type);
+
+        // DAO -> DTO 변환 및 반환
+        return createPhotosDTOBean.exec(photoDAOList);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/SavePhotoBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/SavePhotoBean.java
@@ -1,0 +1,38 @@
+package com.DevTino.festino_main.event.photo.bean;
+
+import com.DevTino.festino_main.event.photo.bean.small.CreatePhotoDAOBean;
+import com.DevTino.festino_main.event.photo.bean.small.SavePhotoDAOBean;
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class SavePhotoBean {
+
+    CreatePhotoDAOBean createPhotoDAOBean;
+    SavePhotoDAOBean savePhotoDAOBean;
+
+    @Autowired
+    public SavePhotoBean(CreatePhotoDAOBean createPhotoDAOBean, SavePhotoDAOBean savePhotoDAOBean){
+        this.createPhotoDAOBean = createPhotoDAOBean;
+        this.savePhotoDAOBean = savePhotoDAOBean;
+    }
+
+    public UUID exec(RequestPhotoSaveDTO requestPhotoSaveDTO){
+
+        // 유저 정보 가져오기
+
+        // 포토 DAO 생성
+        PhotoDAO photoDAO = createPhotoDAOBean.exec("test", requestPhotoSaveDTO);
+        if (photoDAO == null) return null;
+
+        // DAO 저장
+        savePhotoDAOBean.exec(photoDAO);
+
+        // reviewID 반환
+        return photoDAO.getPhotoId();
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotoDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotoDAOBean.java
@@ -1,0 +1,24 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+public class CreatePhotoDAOBean {
+
+    public PhotoDAO exec(String mainUserName, RequestPhotoSaveDTO requestPhotoSaveDTO) {
+
+        return PhotoDAO.builder()
+                .photoId(UUID.randomUUID())
+                .mainUserId(requestPhotoSaveDTO.getMainUserId())
+                .mainUserName(mainUserName)
+                .imageUrl(requestPhotoSaveDTO.getImageUrl())
+                .heartCount(0)
+                .createAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotosDTOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotosDTOBean.java
@@ -1,0 +1,25 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.dto.ResponsePhotoGetDTO;
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CreatePhotosDTOBean {
+
+    public List<ResponsePhotoGetDTO> exec(List<PhotoDAO> photoDAOList) {
+        return photoDAOList.stream()
+                .map(photoDAO -> {
+                    ResponsePhotoGetDTO responsePhotoGetDTO = new ResponsePhotoGetDTO();
+                    responsePhotoGetDTO.setPhotoId(photoDAO.getPhotoId());
+                    responsePhotoGetDTO.setMainUserName(photoDAO.getMainUserName());
+                    responsePhotoGetDTO.setImageUrl(photoDAO.getImageUrl());
+                    responsePhotoGetDTO.setCreateAt(photoDAO.getCreateAt());
+                    responsePhotoGetDTO.setHeartCount(photoDAO.getHeartCount());
+                    return responsePhotoGetDTO;
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotosDTOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/CreatePhotosDTOBean.java
@@ -5,12 +5,30 @@ import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 
 @Component
 public class CreatePhotosDTOBean {
 
+    // 전체 조회
     public List<ResponsePhotoGetDTO> exec(List<PhotoDAO> photoDAOList) {
         return photoDAOList.stream()
+                .map(photoDAO -> {
+                    ResponsePhotoGetDTO responsePhotoGetDTO = new ResponsePhotoGetDTO();
+                    responsePhotoGetDTO.setPhotoId(photoDAO.getPhotoId());
+                    responsePhotoGetDTO.setMainUserName(photoDAO.getMainUserName());
+                    responsePhotoGetDTO.setImageUrl(photoDAO.getImageUrl());
+                    responsePhotoGetDTO.setCreateAt(photoDAO.getCreateAt());
+                    responsePhotoGetDTO.setHeartCount(photoDAO.getHeartCount());
+                    return responsePhotoGetDTO;
+                })
+                .toList();
+    }
+
+    // 유저의 사진 조회
+    public List<ResponsePhotoGetDTO> exec(UUID mainUserId, List<PhotoDAO> photoDAOList) {
+        return photoDAOList.stream()
+                .filter(photoDAO -> photoDAO.getMainUserId().equals(mainUserId)) // 조건 추가
                 .map(photoDAO -> {
                     ResponsePhotoGetDTO responsePhotoGetDTO = new ResponsePhotoGetDTO();
                     responsePhotoGetDTO.setPhotoId(photoDAO.getPhotoId());

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/DeletePhotoDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/DeletePhotoDAOBean.java
@@ -1,0 +1,24 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import com.DevTino.festino_main.event.photo.repository.PhotoRepositoryJPA;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class DeletePhotoDAOBean {
+
+    PhotoRepositoryJPA photoRepositoryJPA;
+
+    @Autowired
+    public DeletePhotoDAOBean(PhotoRepositoryJPA photoRepositoryJPA) {
+        this.photoRepositoryJPA = photoRepositoryJPA;
+    }
+
+    // 포토 DAO 삭제
+    public void exec(PhotoDAO photoDAO) {
+        photoRepositoryJPA.delete(photoDAO);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/GetPhotoDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/GetPhotoDAOBean.java
@@ -1,0 +1,24 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import com.DevTino.festino_main.event.photo.repository.PhotoRepositoryJPA;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class GetPhotoDAOBean {
+
+    PhotoRepositoryJPA photoRepositoryJPA;
+
+    @Autowired
+    public GetPhotoDAOBean(PhotoRepositoryJPA photoRepositoryJPA) {
+        this.photoRepositoryJPA = photoRepositoryJPA;
+    }
+
+    // 포토 DAO 가져오기
+    public PhotoDAO exec(UUID photoId) {
+        return photoRepositoryJPA.findById(photoId).orElse(null);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/GetPhotosDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/GetPhotosDAOBean.java
@@ -1,0 +1,31 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import com.DevTino.festino_main.event.photo.repository.PhotoRepositoryJPA;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetPhotosDAOBean {
+
+    PhotoRepositoryJPA photoRepositoryJPA;
+
+    @Autowired
+    public GetPhotosDAOBean(PhotoRepositoryJPA photoRepositoryJPA) {
+        this.photoRepositoryJPA = photoRepositoryJPA;
+    }
+
+    // 사진 타입 별로 정렬해서 가져오기
+    public List<PhotoDAO> exec(String type){
+        // 타입 판단
+        if (type.equals("new")) {
+            return photoRepositoryJPA.findAllByOrderByCreateAtDesc();
+        } else if (type.equals("heart")) {
+            return photoRepositoryJPA.findAllByOrderByHeartCountDesc();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/bean/small/SavePhotoDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/bean/small/SavePhotoDAOBean.java
@@ -1,0 +1,22 @@
+package com.DevTino.festino_main.event.photo.bean.small;
+
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import com.DevTino.festino_main.event.photo.repository.PhotoRepositoryJPA;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavePhotoDAOBean {
+
+    PhotoRepositoryJPA photoRepositoryJPA;
+
+    @Autowired
+    public SavePhotoDAOBean(PhotoRepositoryJPA photoRepositoryJPA) {
+        this.photoRepositoryJPA = photoRepositoryJPA;
+    }
+
+    public void exec(PhotoDAO photoDAO) {
+        // 포토 DAO 저장
+        photoRepositoryJPA.save(photoDAO);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
@@ -2,6 +2,7 @@ package com.DevTino.festino_main.event.photo.controller;
 
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import com.DevTino.festino_main.event.photo.domain.dto.ResponsePhotoGetDTO;
 import com.DevTino.festino_main.event.photo.service.PhotoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -22,6 +24,26 @@ public class PhotoController {
     @Autowired
     public PhotoController(PhotoService photoService) {
         this.photoService = photoService;
+    }
+
+    // 사진 게시물 전체 조회
+    @GetMapping("all/{type}") // type : new, heart
+    public ResponseEntity<Map<String, Object>> getPhotos(@PathVariable("type") String type) {
+
+        // 사진 게시물 전체 조회 service 실행
+        List<ResponsePhotoGetDTO> responsePhotoGetDTOList = photoService.getPhotos(type);
+
+        // 사진 게시물 전체 조회 성공 여부 설정
+        boolean success = responsePhotoGetDTOList != null;
+
+        // Map 이용해서 메시지와 id 값 json 데이터로 변환
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("success", success);
+        requestMap.put("message", success ? "사진 게시물 조회 성공" : "사진 게시물 조회 시 DAO 검색 실패");
+        requestMap.put("photoInfo", responsePhotoGetDTOList);
+
+        // status, body 설정해서 응답 리턴
+        return ResponseEntity.status(HttpStatus.OK).body(requestMap);
     }
 
     // 사진 게시물 등록

--- a/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
@@ -46,6 +46,27 @@ public class PhotoController {
         return ResponseEntity.status(HttpStatus.OK).body(requestMap);
     }
 
+    // 유저 사진 게시물 전체 조회
+    @GetMapping("all/{type}/user/{mainUserId}")
+    public ResponseEntity<Map<String, Object>> getUserPhotos(@PathVariable("type") String type, @PathVariable("mainUserId") UUID mainUserId) {
+
+        // 사진 게시물 전체 조회 service 실행
+        List<ResponsePhotoGetDTO> responsePhotoGetDTOList = photoService.getMainUserPhotos(mainUserId, type);
+
+        // 사진 게시물 전체 조회 성공 여부 설정
+        boolean success = responsePhotoGetDTOList != null;
+
+        // Map 이용해서 메시지와 id 값 json 데이터로 변환
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("success", success);
+        requestMap.put("message", success ? "사진 게시물 조회 성공" : "사진 게시물 조회 시 DAO 검색 실패");
+        requestMap.put("photoInfo", responsePhotoGetDTOList);
+
+        // status, body 설정해서 응답 리턴
+        return ResponseEntity.status(HttpStatus.OK).body(requestMap);
+    }
+
+
     // 사진 게시물 등록
     @PostMapping
     public ResponseEntity<Map<String, Object>> savePhoto(@RequestBody RequestPhotoSaveDTO requestPhotoSaveDTO) {

--- a/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
@@ -1,0 +1,41 @@
+package com.DevTino.festino_main.event.photo.controller;
+
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import com.DevTino.festino_main.event.photo.service.PhotoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@CrossOrigin("*")
+@RequestMapping("/main/event/photo")
+public class PhotoController {
+
+    PhotoService photoService;
+
+    @Autowired
+    public PhotoController(PhotoService photoService) {
+        this.photoService = photoService;
+    }
+
+    // 사진 게시물 등록
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> savePhoto(@RequestBody RequestPhotoSaveDTO requestPhotoSaveDTO) {
+
+        UUID photoId = photoService.savePhoto(requestPhotoSaveDTO);
+
+        boolean success = photoId != null;
+
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("success", success);
+        requestMap.put("message", success ? "사진 게시물 저장 성공" : "사진 게시물 저장 실패");
+        requestMap.put("reviewId", photoId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(requestMap);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/controller/PhotoController.java
@@ -1,5 +1,6 @@
 package com.DevTino.festino_main.event.photo.controller;
 
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
 import com.DevTino.festino_main.event.photo.service.PhotoService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,5 +38,20 @@ public class PhotoController {
         requestMap.put("reviewId", photoId);
 
         return ResponseEntity.status(HttpStatus.OK).body(requestMap);
+    }
+
+    // 사진 게시물 삭제
+    @DeleteMapping
+    public ResponseEntity<Map<String, Object>> deletePhoto(@RequestBody RequestPhotoDeleteDTO requestPhotoDeleteDTO) {
+
+        UUID photoId = photoService.deletePhoto(requestPhotoDeleteDTO);
+
+        boolean success = photoId != null;
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("success", success);
+        responseMap.put("message", success ? "사진 게시물 삭제 성공" : "사진 게시물 삭제 실패");
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseMap);
     }
 }

--- a/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/RequestPhotoDeleteDTO.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/RequestPhotoDeleteDTO.java
@@ -1,0 +1,11 @@
+package com.DevTino.festino_main.event.photo.domain.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class RequestPhotoDeleteDTO {
+    private UUID photoId;
+    private UUID mainUserId;
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/RequestPhotoSaveDTO.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/RequestPhotoSaveDTO.java
@@ -1,0 +1,11 @@
+package com.DevTino.festino_main.event.photo.domain.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class RequestPhotoSaveDTO {
+    private UUID mainUserId;
+    private String imageUrl;
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/ResponsePhotoGetDTO.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/domain/dto/ResponsePhotoGetDTO.java
@@ -1,0 +1,15 @@
+package com.DevTino.festino_main.event.photo.domain.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+public class ResponsePhotoGetDTO {
+    private UUID photoId;
+    private String mainUserName;
+    private String imageUrl;
+    private Integer heartCount;
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/domain/entity/PhotoDAO.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/domain/entity/PhotoDAO.java
@@ -1,0 +1,26 @@
+package com.DevTino.festino_main.event.photo.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PhotoDAO {
+
+    @Id
+    private UUID photoId;
+    private UUID mainUserId;
+
+    private String mainUserName;
+    private String imageUrl;
+    private Integer heartCount;
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/repository/PhotoRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/repository/PhotoRepositoryJPA.java
@@ -3,7 +3,14 @@ package com.DevTino.festino_main.event.photo.repository;
 import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PhotoRepositoryJPA extends JpaRepository<PhotoDAO, UUID> {
+
+    // 사진 타입 별로 정렬해서 가져오기
+    List<PhotoDAO> findAllByOrderByCreateAtDesc();
+
+    List<PhotoDAO> findAllByOrderByHeartCountDesc();
+
 }

--- a/src/main/java/com/DevTino/festino_main/event/photo/repository/PhotoRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/repository/PhotoRepositoryJPA.java
@@ -1,0 +1,9 @@
+package com.DevTino.festino_main.event.photo.repository;
+
+import com.DevTino.festino_main.event.photo.domain.entity.PhotoDAO;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PhotoRepositoryJPA extends JpaRepository<PhotoDAO, UUID> {
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
@@ -1,24 +1,34 @@
 package com.DevTino.festino_main.event.photo.service;
 
 import com.DevTino.festino_main.event.photo.bean.DeletePhotoBean;
+import com.DevTino.festino_main.event.photo.bean.GetPhotosBean;
 import com.DevTino.festino_main.event.photo.bean.SavePhotoBean;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import com.DevTino.festino_main.event.photo.domain.dto.ResponsePhotoGetDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
 public class PhotoService {
 
+    GetPhotosBean getPhotosBean;
     SavePhotoBean savePhotoBean;
     DeletePhotoBean deletePhotoBean;
 
     @Autowired
-    public PhotoService(SavePhotoBean savePhotoBean, DeletePhotoBean deletePhotoBean) {
+    public PhotoService(GetPhotosBean getPhotosBean, SavePhotoBean savePhotoBean, DeletePhotoBean deletePhotoBean) {
+        this.getPhotosBean = getPhotosBean;
         this.savePhotoBean = savePhotoBean;
         this.deletePhotoBean = deletePhotoBean;
+    }
+
+    // 사진 게시물 가져오기
+    public List<ResponsePhotoGetDTO> getPhotos(String type) {
+        return getPhotosBean.exec(type);
     }
 
     // 사진 게시물 등록

--- a/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
@@ -1,0 +1,25 @@
+package com.DevTino.festino_main.event.photo.service;
+
+import com.DevTino.festino_main.event.photo.bean.SavePhotoBean;
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class PhotoService {
+
+    SavePhotoBean savePhotoBean;
+
+    @Autowired
+    public PhotoService(SavePhotoBean savePhotoBean) {
+        this.savePhotoBean = savePhotoBean;
+    }
+
+    // 사진 게시물 등록
+    public UUID savePhoto(RequestPhotoSaveDTO requestPhotoSaveDTO) {
+        return savePhotoBean.exec(requestPhotoSaveDTO);
+    }
+
+}

--- a/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
@@ -1,6 +1,7 @@
 package com.DevTino.festino_main.event.photo.service;
 
 import com.DevTino.festino_main.event.photo.bean.DeletePhotoBean;
+import com.DevTino.festino_main.event.photo.bean.GetMainUserPhotosBean;
 import com.DevTino.festino_main.event.photo.bean.GetPhotosBean;
 import com.DevTino.festino_main.event.photo.bean.SavePhotoBean;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
@@ -16,12 +17,14 @@ import java.util.UUID;
 public class PhotoService {
 
     GetPhotosBean getPhotosBean;
+    GetMainUserPhotosBean getMainUserPhotosBean;
     SavePhotoBean savePhotoBean;
     DeletePhotoBean deletePhotoBean;
 
     @Autowired
-    public PhotoService(GetPhotosBean getPhotosBean, SavePhotoBean savePhotoBean, DeletePhotoBean deletePhotoBean) {
+    public PhotoService(GetPhotosBean getPhotosBean, GetMainUserPhotosBean getMainUserPhotosBean, SavePhotoBean savePhotoBean, DeletePhotoBean deletePhotoBean) {
         this.getPhotosBean = getPhotosBean;
+        this.getMainUserPhotosBean = getMainUserPhotosBean;
         this.savePhotoBean = savePhotoBean;
         this.deletePhotoBean = deletePhotoBean;
     }
@@ -29,6 +32,11 @@ public class PhotoService {
     // 사진 게시물 가져오기
     public List<ResponsePhotoGetDTO> getPhotos(String type) {
         return getPhotosBean.exec(type);
+    }
+
+    // 유저의 사진 게시물 가져오기
+    public List<ResponsePhotoGetDTO> getMainUserPhotos(UUID mainUserId, String type) {
+        return getMainUserPhotosBean.exec(mainUserId, type);
     }
 
     // 사진 게시물 등록

--- a/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
+++ b/src/main/java/com/DevTino/festino_main/event/photo/service/PhotoService.java
@@ -1,6 +1,8 @@
 package com.DevTino.festino_main.event.photo.service;
 
+import com.DevTino.festino_main.event.photo.bean.DeletePhotoBean;
 import com.DevTino.festino_main.event.photo.bean.SavePhotoBean;
+import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoDeleteDTO;
 import com.DevTino.festino_main.event.photo.domain.dto.RequestPhotoSaveDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -11,10 +13,12 @@ import java.util.UUID;
 public class PhotoService {
 
     SavePhotoBean savePhotoBean;
+    DeletePhotoBean deletePhotoBean;
 
     @Autowired
-    public PhotoService(SavePhotoBean savePhotoBean) {
+    public PhotoService(SavePhotoBean savePhotoBean, DeletePhotoBean deletePhotoBean) {
         this.savePhotoBean = savePhotoBean;
+        this.deletePhotoBean = deletePhotoBean;
     }
 
     // 사진 게시물 등록
@@ -22,4 +26,8 @@ public class PhotoService {
         return savePhotoBean.exec(requestPhotoSaveDTO);
     }
 
+    // 사진 게시물 삭제
+    public UUID deletePhoto(RequestPhotoDeleteDTO requestPhotoDeleteDTO) {
+        return deletePhotoBean.exec(requestPhotoDeleteDTO);
+    }
 }


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Main-BE/issues/85)


## Changes
- [x] 전체 게시물 조회 API (최신순, 좋아요순)

- [x] 내 게시물 조회 API (최신순, 좋아요순)

- [x] 게시물 등록 API

- [x] 게시물 삭제 API

## Review Points

사진 게시물 관련 API가 잘 동작 하는가
- event/photo
  - 게시물 생성 : `/main/event/photo`