### PR TITLE
fix : event-real-time

### DIFF
--- a/src/main/java/com/DevTino/festino_main/event/real/bean/GetRealTimeQuestionBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/real/bean/GetRealTimeQuestionBean.java
@@ -1,5 +1,6 @@
 package com.DevTino.festino_main.event.real.bean;
 
+import com.DevTino.festino_main.DateTimeUtils;
 import com.DevTino.festino_main.event.real.bean.small.CreateRealTimeQuestionDTOBean;
 import com.DevTino.festino_main.event.real.bean.small.GetRealTimeQuestionDAOBean;
 import com.DevTino.festino_main.event.real.domain.DTO.ResponseRealTimeQuestionGetDTO;
@@ -7,6 +8,7 @@ import com.DevTino.festino_main.event.real.domain.RealTimeQuestionDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Component
@@ -22,10 +24,14 @@ public class GetRealTimeQuestionBean {
     }
 
     public ResponseRealTimeQuestionGetDTO exec(){
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = DateTimeUtils.nowZone();
+        LocalDate today = now.toLocalDate();
+
+        LocalDateTime todayStart = today.atTime(0, 0);
+        LocalDateTime todayEnd = today.atTime(23, 59, 59);
 
         // 현재 시간이 startTime, endTime 안에 있는 DAO 가져오기
-        RealTimeQuestionDAO realTimeQuestionDAO = getRealTimeQuestionDAOBean.exec(now);
+        RealTimeQuestionDAO realTimeQuestionDAO = getRealTimeQuestionDAOBean.exec(todayStart, todayEnd, now);
         if (realTimeQuestionDAO == null) return null;
 
         // DTO 생성 후 반환

--- a/src/main/java/com/DevTino/festino_main/event/real/bean/GetRealTimeQuestionNextTimeBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/real/bean/GetRealTimeQuestionNextTimeBean.java
@@ -1,5 +1,6 @@
 package com.DevTino.festino_main.event.real.bean;
 
+import com.DevTino.festino_main.DateTimeUtils;
 import com.DevTino.festino_main.event.real.bean.small.CreateRealTimeQuestionNextTimeDTOBean;
 import com.DevTino.festino_main.event.real.bean.small.GetRealTimeQuestionDAOBean;
 import com.DevTino.festino_main.event.real.domain.DTO.ResponseRealTimeQuestionNextTimeGetDTO;
@@ -7,7 +8,9 @@ import com.DevTino.festino_main.event.real.domain.RealTimeQuestionDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Component
 public class GetRealTimeQuestionNextTimeBean {
@@ -23,10 +26,14 @@ public class GetRealTimeQuestionNextTimeBean {
 
     public ResponseRealTimeQuestionNextTimeGetDTO exec(){
         // 현재 시간 가져오기
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = DateTimeUtils.nowZone();
+        LocalDate today = now.toLocalDate();
+
+        LocalDateTime todayStart = today.atTime(0, 0);
+        LocalDateTime todayEnd = today.atTime(23, 59, 59);
 
         // 현재 시간에 맞춰 다음시간인 퀴즈 시작시간, 종료시간 가져오기
-        RealTimeQuestionDAO realTimeQuestionDAO = getRealTimeQuestionDAOBean.exec(now);
+        RealTimeQuestionDAO realTimeQuestionDAO = getRealTimeQuestionDAOBean.exec(todayStart, todayEnd, now);
         if (realTimeQuestionDAO == null) return null;
 
         // 시작시간, 종료시간가 담긴 DTO 객체 반환

--- a/src/main/java/com/DevTino/festino_main/event/real/bean/small/CreateRealTimeQuestionDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/real/bean/small/CreateRealTimeQuestionDAOBean.java
@@ -34,11 +34,11 @@ public class CreateRealTimeQuestionDAOBean {
 //        LocalDateTime endTime = targetDate.atTime(18, 10);
 
         // 테스트용
-        LocalDate baseDate = LocalDate.of(2025, 5, 11);
+        LocalDate baseDate = LocalDate.of(2025, 5, 17);
         LocalDate targetDate = baseDate.plusDays(count);
 
-        LocalDateTime startTime = targetDate.atTime(0, 1);
-        LocalDateTime endTime = targetDate.atTime(23, 59);
+        LocalDateTime startTime = targetDate.atTime(2, 0);
+        LocalDateTime endTime = targetDate.atTime(22, 0);
 
 
         return RealTimeQuestionDAO.builder()

--- a/src/main/java/com/DevTino/festino_main/event/real/bean/small/GetRealTimeQuestionDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/event/real/bean/small/GetRealTimeQuestionDAOBean.java
@@ -18,8 +18,14 @@ public class GetRealTimeQuestionDAOBean {
     }
 
     // 현재 시간이 startTime, endTime 안에 있는 DAO 가져오기
-    public RealTimeQuestionDAO exec(LocalDateTime now){
-        return realTimeRepositoryJPA.findTop1ByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeAsc(now, now);
+    public RealTimeQuestionDAO exec(LocalDateTime todayStart, LocalDateTime todayEnd, LocalDateTime now){
+        RealTimeQuestionDAO realTimeQuestionDAO = realTimeRepositoryJPA.findTop1ByStartTimeBetweenAndStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeAsc(todayStart, todayEnd, now, now).orElse(null);
+
+        if (realTimeQuestionDAO != null){
+            return realTimeQuestionDAO;
+        } else {
+            return realTimeRepositoryJPA.findTop1ByStartTimeAfterOrderByStartTimeAsc(now).orElse(null);
+        }
     }
 
 //    public RealTimeQuestionDAO exec(LocalDateTime now){

--- a/src/main/java/com/DevTino/festino_main/event/real/repository/RealTimeRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_main/event/real/repository/RealTimeRepositoryJPA.java
@@ -4,10 +4,15 @@ import com.DevTino.festino_main.event.real.domain.RealTimeQuestionDAO;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface RealTimeRepositoryJPA extends JpaRepository<RealTimeQuestionDAO, UUID> {
 
     // 현재 시간이 startTime ~ endTime 사이에 있는 문제만 조회
-    RealTimeQuestionDAO findTop1ByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeAsc(LocalDateTime now1, LocalDateTime now2);
+    Optional<RealTimeQuestionDAO> findTop1ByStartTimeBetweenAndStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeAsc(LocalDateTime todayStart, LocalDateTime todayEnd, LocalDateTime now1, LocalDateTime now2);
+
+
+    // 현재 시간이 startTime ~ endTime 사이에 있는 문제가 아닐 때, 이후 가장 빠른 퀴즈를 조회
+    Optional<RealTimeQuestionDAO> findTop1ByStartTimeAfterOrderByStartTimeAsc(LocalDateTime now);
 }


### PR DESCRIPTION
## Docs

- [Issue Link] 


## Changes

- 실시간 다음 퀴즈 시간 조회 API 수정

## Review Points

- 실시간 퀴즈 이벤트 다음 퀴즈 시간이 제대로 조회되는가?

## Test Checklist

- [x] check 1 : 다른 버그나 고칠 사항은 없는가 