### PR TITLE
fix : user save and authorization

### DIFF
--- a/src/main/java/com/DevTino/festino_main/exception/ExceptionEnum.java
+++ b/src/main/java/com/DevTino/festino_main/exception/ExceptionEnum.java
@@ -26,6 +26,7 @@ public enum ExceptionEnum {
     CSRF_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "E017", "CSRF 토큰이 만료되었습니다."),
     RESERVATION_DISABLED(HttpStatus.FORBIDDEN, "E018", "예약이 비활성화된 상태입니다."),
     AUTHCODE_MISMATCH(HttpStatus.UNAUTHORIZED, "E019", "인증코드가 일치하지 않습니다."),
+    MESSAGE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E020", "메시지 전송에 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
     // 공통 예외
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");

--- a/src/main/java/com/DevTino/festino_main/message/bean/small/GetAccessTokenBean.java
+++ b/src/main/java/com/DevTino/festino_main/message/bean/small/GetAccessTokenBean.java
@@ -1,5 +1,7 @@
 package com.DevTino.festino_main.message.bean.small;
 
+import com.DevTino.festino_main.exception.ExceptionEnum;
+import com.DevTino.festino_main.exception.ServiceException;
 import com.DevTino.festino_main.message.others.SmsConfig;
 import com.google.gson.Gson;
 import okhttp3.*;
@@ -24,28 +26,31 @@ public class GetAccessTokenBean {
         this.smsConfig = smsConfig;
     }
 
-    public String exec() throws IOException {
-        String authValue = Base64.getEncoder()
-                .encodeToString(String.format("%s:%s", smsConfig.getSmsId(), smsConfig.getApiKey()).getBytes(StandardCharsets.UTF_8));
+    public String exec() {
+        try {
+            String authValue = Base64.getEncoder()
+                    .encodeToString(String.format("%s:%s", smsConfig.getSmsId(), smsConfig.getApiKey()).getBytes(StandardCharsets.UTF_8));
 
-        OkHttpClient client = new OkHttpClient();
+            OkHttpClient client = new OkHttpClient();
 
-        RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
-                .addFormDataPart("grant_type", "client_credentials")
-                .build();
+            RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
+                    .addFormDataPart("grant_type", "client_credentials")
+                    .build();
 
-        Request request = new Request.Builder()
-                .url(SMS_OAUTH_TOKEN_URL)
-                .post(requestBody)
-                .addHeader("Content-Type", CONTENT_TYPE)
-                .addHeader("Authorization", "Basic " + authValue)
-                .addHeader("cache-control", CACHE_CONTROL)
-                .build();
+            Request request = new Request.Builder()
+                    .url(SMS_OAUTH_TOKEN_URL)
+                    .post(requestBody)
+                    .addHeader("Content-Type", CONTENT_TYPE)
+                    .addHeader("Authorization", "Basic " + authValue)
+                    .addHeader("cache-control", CACHE_CONTROL)
+                    .build();
 
-        Response response = client.newCall(request).execute();
-        HashMap<String, String> result = new Gson().fromJson(Objects.requireNonNull(response.body()).string(), HashMap.class);
+            Response response = client.newCall(request).execute();
+            HashMap<String, String> result = new Gson().fromJson(Objects.requireNonNull(response.body()).string(), HashMap.class);
 
-        return result.get("access_token"); // ACCESS TOKEN
-
+            return result.get("access_token"); // ACCESS TOKEN
+        } catch (IOException e) {
+            throw new ServiceException(ExceptionEnum.INTERNAL_ERROR);
+        }
     }
 }

--- a/src/main/java/com/DevTino/festino_main/message/bean/small/SendMessageContentBean.java
+++ b/src/main/java/com/DevTino/festino_main/message/bean/small/SendMessageContentBean.java
@@ -1,5 +1,7 @@
 package com.DevTino.festino_main.message.bean.small;
 
+import com.DevTino.festino_main.exception.ExceptionEnum;
+import com.DevTino.festino_main.exception.ServiceException;
 import com.DevTino.festino_main.message.others.SmsConfig;
 import com.google.gson.Gson;
 import okhttp3.*;
@@ -24,38 +26,42 @@ public class SendMessageContentBean {
         this.smsConfig = smsConfig;
     }
 
-    public String exec(String phoneNum, String accessToken, String refKey, String message) throws IOException {
+    public String exec(String phoneNum, String accessToken, String refKey, String message) {
 
-        String authValue =
-                Base64.getEncoder().encodeToString(String.format("%s:%s", smsConfig.getSmsId(),
-                        accessToken).getBytes(StandardCharsets.UTF_8)); // Authorization Header 에 입력할 값입니다.
+        try {
+            String authValue =
+                    Base64.getEncoder().encodeToString(String.format("%s:%s", smsConfig.getSmsId(),
+                            accessToken).getBytes(StandardCharsets.UTF_8)); // Authorization Header 에 입력할 값입니다.
 
-        // SMS 발송 API 를 호출합니다.
-        OkHttpClient client1 = new OkHttpClient();
+            // SMS 발송 API 를 호출합니다.
+            OkHttpClient client1 = new OkHttpClient();
 
-        RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
-                .addFormDataPart("phone", phoneNum)
-                .addFormDataPart("callback", smsConfig.getCallBack()) // 발신번호를 입력해 주세요.
-                .addFormDataPart("message", message) // SMS 내용을 입력해 주세요.
-                .addFormDataPart("refkey", refKey) // 발송 결과 조회를 위한 임의의 랜덤 키 값을 입력해 주세요.
-                .build();
+            RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
+                    .addFormDataPart("phone", phoneNum)
+                    .addFormDataPart("callback", smsConfig.getCallBack()) // 발신번호를 입력해 주세요.
+                    .addFormDataPart("message", message) // SMS 내용을 입력해 주세요.
+                    .addFormDataPart("refkey", refKey) // 발송 결과 조회를 위한 임의의 랜덤 키 값을 입력해 주세요.
+                    .build();
 
-        Request request1 = new Request.Builder()
-                .url(SMS_SEND_URL)
-                .post(requestBody)
-                .addHeader("Content-Type", CONTENT_TYPE)
-                .addHeader("Authorization", "Basic " + authValue)
-                .addHeader("cache-control", CACHE_CONTROL)
-                .build();
+            Request request1 = new Request.Builder()
+                    .url(SMS_SEND_URL)
+                    .post(requestBody)
+                    .addHeader("Content-Type", CONTENT_TYPE)
+                    .addHeader("Authorization", "Basic " + authValue)
+                    .addHeader("cache-control", CACHE_CONTROL)
+                    .build();
 
-        Response response = client1.newCall(request1).execute();
+            Response response = client1.newCall(request1).execute();
 
-        // Response 를 key, value 로 확인하실 수 있습니다.
-        if (response.isSuccessful()) {
-            HashMap<String, String> result = new Gson().fromJson(Objects.requireNonNull(response.body()).string(), HashMap.class);
-            if (result.get("code").equals("200"))
-                return "SEND_SUCCESS";
+            // Response 를 key, value 로 확인하실 수 있습니다.
+            if (response.isSuccessful()) {
+                HashMap<String, String> result = new Gson().fromJson(Objects.requireNonNull(response.body()).string(), HashMap.class);
+                if (result.get("code").equals("200"))
+                    return "SEND_SUCCESS";
+            }
+            return "SEND_FAIL";
+        } catch (IOException e) {
+            throw new ServiceException(ExceptionEnum.INTERNAL_ERROR);
         }
-        return "SEND_FAIL";
     }
 }

--- a/src/main/java/com/DevTino/festino_main/user/bean/SaveMainUserBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/SaveMainUserBean.java
@@ -25,7 +25,7 @@ public class SaveMainUserBean {
 
     public UUID exec(RequestMainUserSaveDTO requestMainUserSaveDTO){
 
-        // 사용자 정보가 있는지 조회
+        // 사용자 정보 조회
         MainUserDAO mainUserDAO = getMainUserDAOBean.exec(requestMainUserSaveDTO.getPhoneNum(), requestMainUserSaveDTO.getMainUserName());
 
         if (mainUserDAO.isAuthenticated()) throw new ServiceException(ExceptionEnum.ALREADY_PROCESSED);

--- a/src/main/java/com/DevTino/festino_main/user/bean/SendMessageMainUserAuthorizationBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/SendMessageMainUserAuthorizationBean.java
@@ -9,7 +9,6 @@ import com.DevTino.festino_main.user.domain.entity.MainUserDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.UUID;
 
@@ -33,7 +32,7 @@ public class SendMessageMainUserAuthorizationBean {
     }
 
     // 인증코드 전송
-    public UUID exec(RequestMainUserSaveDTO requestMainUserSaveDTO) throws IOException {
+    public UUID exec(RequestMainUserSaveDTO requestMainUserSaveDTO) {
 
         // 인증코드 생성
         String authorizationCode = String.valueOf(100000 + secureRandom.nextInt(900000));

--- a/src/main/java/com/DevTino/festino_main/user/bean/small/CheckMainUserDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/small/CheckMainUserDAOBean.java
@@ -1,0 +1,23 @@
+package com.DevTino.festino_main.user.bean.small;
+
+import com.DevTino.festino_main.user.repository.MainUserRepositoryJPA;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CheckMainUserDAOBean {
+
+    MainUserRepositoryJPA mainUserRepositoryJPA;
+
+    @Autowired
+    public CheckMainUserDAOBean(MainUserRepositoryJPA mainUserRepositoryJPA) {
+        this.mainUserRepositoryJPA = mainUserRepositoryJPA;
+    }
+
+
+
+    // 번호&이름으로 검색해 유저 존재 여부 반환
+    public boolean exec(String phoneNum, String mainUserName) {
+        return mainUserRepositoryJPA.existsByPhoneNumAndMainUserName(phoneNum, mainUserName);
+    }
+}

--- a/src/main/java/com/DevTino/festino_main/user/bean/small/GetMainUserDAOBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/small/GetMainUserDAOBean.java
@@ -21,7 +21,6 @@ public class GetMainUserDAOBean {
 
     public MainUserDAO exec(UUID mainUserId) {
 
-        // 사용자 정보가 있는지 조회
         MainUserDAO dao = mainUserRepositoryJPA.findByMainUserId(mainUserId);
         if (dao == null) throw new ServiceException(ExceptionEnum.ENTITY_NOT_FOUND);
 
@@ -31,7 +30,7 @@ public class GetMainUserDAOBean {
 
     // 사용자 정보 조회
     public MainUserDAO exec(String phoneNum, String mainUserName) {
-        // 사용자 정보가 있는지 조회
+
         MainUserDAO dao = mainUserRepositoryJPA.findByPhoneNumAndMainUserName(phoneNum, mainUserName);
         if (dao == null) throw new ServiceException(ExceptionEnum.ENTITY_NOT_FOUND);
 

--- a/src/main/java/com/DevTino/festino_main/user/bean/small/SendMessageBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/small/SendMessageBean.java
@@ -1,5 +1,7 @@
 package com.DevTino.festino_main.user.bean.small;
 
+import com.DevTino.festino_main.exception.ExceptionEnum;
+import com.DevTino.festino_main.exception.ServiceException;
 import com.DevTino.festino_main.message.bean.small.CheckMessageStatusBean;
 import com.DevTino.festino_main.message.bean.small.GetAccessTokenBean;
 import com.DevTino.festino_main.message.bean.small.GetCustomMessageDAOBean;
@@ -28,14 +30,14 @@ public class SendMessageBean {
     public String exec(String phoneNum, String authorizationCode) {
 
         String accessToken = getAccessTokenBean.exec();
-        if (accessToken == null) return "SEND_FAIL";
+        if (accessToken == null) throw new ServiceException(ExceptionEnum.MESSAGE_SEND_FAIL);
 
         String refKey = UUID.randomUUID().toString();
         String message = "Festino 인증번호 : " + authorizationCode;
         System.out.println("message = " + message);
 
         String messageStatus = sendMessageContentBean.exec(phoneNum, accessToken, refKey, message);
-        if (messageStatus.equals("SEND_FAIL")) return messageStatus;
+        if (messageStatus.equals("SEND_FAIL")) throw new ServiceException(ExceptionEnum.MESSAGE_SEND_FAIL);
 
         return checkMessageStatusBean.exec(refKey, accessToken);
     }

--- a/src/main/java/com/DevTino/festino_main/user/bean/small/SendMessageBean.java
+++ b/src/main/java/com/DevTino/festino_main/user/bean/small/SendMessageBean.java
@@ -7,7 +7,6 @@ import com.DevTino.festino_main.message.bean.small.SendMessageContentBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.UUID;
 
 @Component
@@ -26,7 +25,7 @@ public class SendMessageBean {
         this.getCustomMessageDAOBean = getCustomMessageDAOBean;
     }
 
-    public String exec(String phoneNum, String authorizationCode) throws IOException {
+    public String exec(String phoneNum, String authorizationCode) {
 
         String accessToken = getAccessTokenBean.exec();
         if (accessToken == null) return "SEND_FAIL";

--- a/src/main/java/com/DevTino/festino_main/user/repository/MainUserRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_main/user/repository/MainUserRepositoryJPA.java
@@ -9,4 +9,6 @@ public interface MainUserRepositoryJPA extends JpaRepository<MainUserDAO, UUID> 
 
     MainUserDAO findByMainUserId(UUID mainUserId);
     MainUserDAO findByPhoneNumAndMainUserName(String phoneNum, String mainUserName);
+    boolean existsByPhoneNumAndMainUserName(String phoneNum, String mainUserName);
+
 }

--- a/src/main/java/com/DevTino/festino_main/user/service/MainUserService.java
+++ b/src/main/java/com/DevTino/festino_main/user/service/MainUserService.java
@@ -35,11 +35,6 @@ public class MainUserService {
 
     // 사용자 인증 번호 전송
     public UUID sendMessageMainUserAuthorization(RequestMainUserSaveDTO requestMainUserSaveDTO) {
-        try {
-            return sendMessageMainUserAuthorizationBean.exec(requestMainUserSaveDTO);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
+        return sendMessageMainUserAuthorizationBean.exec(requestMainUserSaveDTO);
     }
 }


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Main-BE/issues/118#issue-3075967288)


## Changes

1. GetAccessTokenBean, SendMessageContentBean의 예외처리 흐름 변경
2. 유저를 가져오기 위한 GetMainUserDAOBean과 유저가 있는지 판단만 하기 위한 CheckMainUserDAOBean을 분리

## Review Points

- 관련 API가 정상 동작하는가

## Test Checklist

- [x] 사용자 인증 번호 전송 - `/main/user/authorization` - `POST`
- [x] 사용자 정보 저장 - `/main/user/authorization` - `GET`